### PR TITLE
check highest index first.

### DIFF
--- a/src/bpt.c
+++ b/src/bpt.c
@@ -32,8 +32,12 @@ struct cache_handler bpt_node_cache_handler = {bpt_node_serialize,
                                                bpt_node_free_mem};
 
 //{{{int b_search(int key, int *D, int D_size)
-int b_search(uint32_t key, uint32_t *D, uint32_t D_size)
+int b_search(uint32_t key, const uint32_t *D, uint32_t D_size)
 {
+    // This is a common case when incoming data is sorted.
+    if(key >= D[D_size-1]) {
+        return D_size;
+    }
     int lo = -1, hi = D_size, mid;
     while ( hi - lo > 1) {
         mid = (hi + lo) / 2;

--- a/src/bpt.h
+++ b/src/bpt.h
@@ -103,7 +103,7 @@ uint32_t bpt_insert_new_value(uint32_t domain,
 //void bpt_print_tree(struct bpt_node *curr, int level);
 //void pbt_print_node(struct bpt_node *bpt_node);
 
-int b_search(uint32_t key, uint32_t *D, uint32_t D_size);
+int b_search(uint32_t key, const uint32_t *D, uint32_t D_size);
 
 int bpt_find_insert_pos(struct bpt_node *leaf, uint32_t key);
 


### PR DESCRIPTION
this improves speed when incoming data is sorted.

without this change `b_search` takes ~ 30% of the run-time for indexing. With this change:

```
Total: 1093 samples
     110  10.1%  10.1%      110  10.1% bit_map_get
      94   8.6%  18.7%       94   8.6% b_search
      83   7.6%  26.3%       86   7.9% _int_malloc
      76   7.0%  33.2%       76   7.0% scan_s
      75   6.9%  40.1%       75   6.9% inflateBackEnd
      63   5.8%  45.8%      250  22.9% bpt_find_leaf
      60   5.5%  51.3%      210  19.2% simple_cache_get
      52   4.8%  56.1%      162  14.8% indexed_list_get
      40   3.7%  59.7%       40   3.7% __write_nocancel
```