### PR TITLE
Add Docker environment instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,3 +396,19 @@ func main() {
     lines = res.Of(1)
 }
 ```
+
+## Docker
+
+### [giggle-docker](https://github.com/kubor/giggle-docker) by Ryuichi Kubo
+
+```
+docker run kubor/giggle-docker giggle -h
+```
+
+```
+Unknown command
+giggle, v0.6.3
+usage:   giggle <command> [options]
+         index     Create an index
+                  search    Search an index
+```


### PR DESCRIPTION
I made GIGGLE docker image.
Users can execute GIGGLE without local build by using this image.

## Usage

```
docker run kubor/giggle-docker giggle -h
```

https://github.com/kubor/giggle-docker